### PR TITLE
Fix a warning problem: Task "jshint:all" failed.

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
       jade: {
         files: ['<%%= yeoman.app %>/views/{,*/}*.jade', '<%%= yeoman.app %>/*.jade'],
         tasks: ['bowerInstall', 'jade:server']
-      }, <% } %>
+      },<% } %>
       gruntfile: {
         files: ['Gruntfile.js']
       },


### PR DESCRIPTION
The reason for that is there a redundant whitespace.